### PR TITLE
Add smoke CI workflow

### DIFF
--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -1,0 +1,27 @@
+name: ci-smoke
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install pnpm
+        run: npm i -g pnpm
+      - name: Install deps (if JS/TS)
+        run: |
+          if [ -f pnpm-lock.yaml ]; then pnpm install --frozen-lockfile; fi
+      - name: Foundry install
+        run: |
+          curl -L https://foundry.paradigm.xyz | bash
+          ~/.foundry/bin/foundryup
+      - name: Build & test (Foundry)
+        run: |
+          if [ -f foundry.toml ] || [ -d src ]; then ~/.foundry/bin/forge --version && ~/.foundry/bin/forge build && ~/.foundry/bin/forge test -vvv; else echo "No Foundry project detected, skipping"; fi


### PR DESCRIPTION
## Summary
- add a smoke CI workflow that installs pnpm and Foundry before running forge build and test

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e5d289057c8330bbb88b24b7e5c9ca